### PR TITLE
CommonJS support

### DIFF
--- a/raphael-svg-import.js
+++ b/raphael-svg-import.js
@@ -6,6 +6,9 @@
 */
 
 /* global Raphael, $ */
+if (!Raphael && require){
+  var Raphael = require('raphael');
+}
 Raphael.fn.importSVG = function (svgXML, options) {
   "use strict";
   var myNewSet = this.set();


### PR DESCRIPTION
CommonJS support for npm & browserify.

Example Usage (browserify & superagent):

``` javascript
var Raphael = require('raphael');
require('raphael-svg-import-classic');
var ajax = require('superagent');

ajax.get('assets/levels/level1.svg').end(function(err,res){
    var paper = Raphael(10, 10, 800, 600);
    var newSet = paper.importSVG(res.xhr.responseXML);
});
```
