### PR TITLE
remove jQuery $.trim dependency

### DIFF
--- a/raphael-svg-import.js
+++ b/raphael-svg-import.js
@@ -142,9 +142,9 @@ Raphael.fn.importSVG = function (svgXML, options) {
           styleBitBits;
       for (i = 0; i < styleBits.length; i++) {
         styleBitBits = styleBits[i].split(':');
-        key = $.trim(styleBitBits[0]);
+        key = styleBitBits[0].trim();
         if (key) {
-          attr[key] = $.trim(styleBitBits[1]);
+          attr[key] = styleBitBits[1].trim();
         }
       }
     }

--- a/raphael-svg-import.js
+++ b/raphael-svg-import.js
@@ -5,7 +5,6 @@
 *
 */
 
-/* global Raphael, $ */
 Raphael.fn.importSVG = function (svgXML, options) {
   "use strict";
   var myNewSet = this.set();
@@ -136,15 +135,20 @@ Raphael.fn.importSVG = function (svgXML, options) {
       delete attr.transform;
     }
 
+    // minimal polyfill for String.trim()
+    var trim = function(string){
+        return string.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '');
+    };
+
     // Raphael throws away the `style` attribute; re-interpret it.
     if (attr.style) {
       var styleBits = attr.style.split(';'),
           styleBitBits;
       for (i = 0; i < styleBits.length; i++) {
         styleBitBits = styleBits[i].split(':');
-        key = styleBitBits[0].trim();
+        key = trim(styleBitBits[0]);
         if (key) {
-          attr[key] = styleBitBits[1].trim();
+          attr[key] = trim(styleBitBits[1]);
         }
       }
     }


### PR DESCRIPTION
Using [String.prototype.trim](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim) to remove dependency of jQuery.  This can be polyfilled for <IE9 with this:

```javascript
if (!String.prototype.trim) {
  (function() {
    // Make sure we trim BOM and NBSP
    var rtrim = /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g;
    String.prototype.trim = function() {
      return this.replace(rtrim, '');
    };
  })();
}
```